### PR TITLE
fastboot: Fix hardcoded endpoint number

### DIFF
--- a/lib/fastboot.js
+++ b/lib/fastboot.js
@@ -49,6 +49,8 @@ export class FastbootDevice {
      */
     constructor() {
         this.device = null;
+        this.epIn = null;
+        this.epOut = null;
         this._registeredUsbListeners = false;
         this._connectResolve = null;
         this._connectReject = null;
@@ -78,8 +80,8 @@ export class FastbootDevice {
             throw new UsbError("Interface has wrong number of endpoints");
         }
 
-        let epIn = null;
-        let epOut = null;
+        this.epIn = null;
+        this.epOut = null;
         for (let endpoint of ife.endpoints) {
             common.logVerbose("Checking endpoint:", endpoint);
             if (endpoint.type !== "bulk") {
@@ -87,20 +89,20 @@ export class FastbootDevice {
             }
 
             if (endpoint.direction === "in") {
-                if (epIn === null) {
-                    epIn = endpoint.endpointNumber;
+                if (this.epIn === null) {
+                    this.epIn = endpoint.endpointNumber;
                 } else {
                     throw new UsbError("Interface has multiple IN endpoints");
                 }
             } else if (endpoint.direction === "out") {
-                if (epOut === null) {
-                    epOut = endpoint.endpointNumber;
+                if (this.epOut === null) {
+                    this.epOut = endpoint.endpointNumber;
                 } else {
                     throw new UsbError("Interface has multiple OUT endpoints");
                 }
             }
         }
-        common.logVerbose("Endpoints: in =", epIn, ", out =", epOut);
+        common.logVerbose("Endpoints: in =", this.epIn, ", out =", this.epOut);
 
         try {
             await this.device.open();
@@ -255,7 +257,7 @@ export class FastbootDevice {
         };
         let respStatus;
         do {
-            let respPacket = await this.device.transferIn(0x01, 64);
+            let respPacket = await this.device.transferIn(this.epIn, 64);
             let response = new TextDecoder().decode(respPacket.data);
 
             respStatus = response.substring(0, 4);
@@ -297,7 +299,7 @@ export class FastbootDevice {
 
         // Send raw UTF-8 command
         let cmdPacket = new TextEncoder("utf-8").encode(command);
-        await this.device.transferOut(0x01, cmdPacket);
+        await this.device.transferOut(this.epOut, cmdPacket);
         common.logDebug("Command:", command);
 
         return this._readResponse();
@@ -391,7 +393,7 @@ export class FastbootDevice {
                 );
             }
 
-            await this.device.transferOut(0x01, chunk);
+            await this.device.transferOut(this.epOut, chunk);
 
             remainingBytes -= chunk.byteLength;
             i += 1;


### PR DESCRIPTION
Some devices use a different endpoint number (5 and 6 in my device) under fastboot. This fix will use the endpoint number found during connect to perform transferIn and transferOut operations.