### PR TITLE
use tryReboot() wrapper for all reboots

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -284,7 +284,7 @@ export async function flashZip(
             "reboot",
             "device",
             FASTBOOTD_REBOOT_TIME,
-            device.reboot("fastboot", true, onReconnect)
+            tryReboot(device, "fastboot", onReconnect)
         );
 
         let superName = await device.getVariable("super-partition-name");
@@ -322,7 +322,7 @@ export async function flashZip(
             "reboot",
             "device",
             BOOTLOADER_REBOOT_TIME,
-            device.reboot("bootloader", true, onReconnect)
+            tryReboot(device, "bootloader", onReconnect)
         );
     }
 


### PR DESCRIPTION
reboots sometimes lead to errors being thrown due to the usb device gone missing. the tryReoot() wrapper got introduced for that case but was not used everywhere.

with this PR the `flashFactoryZip()` method uses this wrapper for all of its reboots