### PR TITLE
allow specification of WebUSB instance to support non-browser environments

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -55,7 +55,11 @@ export function readBlobAsBuffer(blob: Blob): Promise<ArrayBuffer> {
 
 function waitForFrame() {
     return new Promise((resolve, _reject) => {
-        window.requestAnimationFrame(resolve);
+        if(typeof process !== 'undefined' && typeof process.nextTick === 'function') {
+            process.nextTick(resolve)
+        } else {
+            window.requestAnimationFrame(resolve);
+        }
     });
 }
 


### PR DESCRIPTION
Similar to your (@kdrag0n) [webinstaller](https://github.com/kdrag0n/android-webinstall), I try to develop an [more universal installer](https://github.com/alangecker/azadidroid) supporting a wider range of devices and other ROMS like Lineage.

for easier development (and some people would even prefer it) I first did a CLI variant using `fastboot.js` in node, which didn't work out of the box.

One obstacle is, that this project expects `navigator.usb` to be present, which makes it difficult to use WebUSB implementation in node like (e.g [npm:usb](https://www.npmjs.com/package/usb)) 

Full node support still not given due to following other expectations, which are not handled in this PR:
- `Blob`  required
- `crypto` required
- `ProgressEvent` required
- `zip.js@2.2.27` doesn't support node
