### PR TITLE
fixed types export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+.idea/
+dist/**

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "1.1.3",
     "description": "JavaScript implementation of fastboot, using WebUSB",
     "main": "dist/fastboot.cjs",
+    "module": "dist/fastboot.mjs",
     "repository": "https://github.com/kdrag0n/fastboot.js",
     "author": "Danny Lin <danny@kdrag0n.dev>",
     "license": "MIT",
@@ -11,21 +12,26 @@
     },
     "devDependencies": {
         "@rollup/plugin-node-resolve": "^11.1.0",
-        "@rollup/plugin-typescript": "^8.2.1",
+        "@rollup/plugin-typescript": "^8.5.0",
         "@types/w3c-web-usb": "^1.0.4",
         "better-docs": "^2.3.2",
         "eslint": "^7.18.0",
         "eslint-config-prettier": "^7.2.0",
         "jsdoc": "^3.6.6",
         "prettier": "^2.2.1",
+        "rimraf": "^5.0.1",
         "rollup": "^2.38.0",
-        "rollup-plugin-terser": "^7.0.2"
+        "rollup-plugin-terser": "^7.0.2",
+        "typescript": "^5.0.4"
     },
     "scripts": {
         "doc": "jsdoc -c jsdoc.json",
-        "build": "rollup -c"
+        "build": "rimraf dist && rollup -c rollup.config.js",
+        "prepublishOnly": "npm run build"
     },
     "files": [
-        "dist/fastboot.*"
-    ]
+        "dist",
+        "src"
+    ],
+    "types": "./dist"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -28,5 +28,5 @@ export default {
             plugins: [terser()],
         },
     ],
-    plugins: [nodeResolve(), typescript()],
+    plugins: [ typescript(), nodeResolve()],
 };

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -5,6 +5,7 @@ import {
     BlobWriter,
     TextWriter,
     Entry,
+    // @ts-ignore
     EntryGetDataOptions,
     Writer,
 } from "@zip.js/zip.js";

--- a/src/fastboot.ts
+++ b/src/fastboot.ts
@@ -159,7 +159,7 @@ export class FastbootDevice {
 
             await this.device!.selectConfiguration(1);
             await this.device!.claimInterface(0); // fastboot
-        } catch (error) {
+        } catch (error: any) {
             // Propagate exception from waitForConnect()
             if (this._connectReject !== null) {
                 this._connectReject(error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,12 @@
         "esModuleInterop": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        // Generate d.ts files
+        "declaration": true,
+        // go to js file when using IDE functions like
+        // "Go to Definition" in VSCode
+        "declarationMap": true
     },
     "include": ["./src/**/*"]
 }


### PR DESCRIPTION
With the current release of the library on NPM, the type declaration files are not present and thus I get the following error when importing it in typescript projects.
![image](https://github.com/kdrag0n/fastboot.js/assets/70640237/0743657b-e492-499f-8fa4-6886b18616f8)

This PR modifies the `tsconfig.json` and `package.json` files to create and point to the .d.ts files.
